### PR TITLE
Fix set encoding of generated source files

### DIFF
--- a/dcc.py
+++ b/dcc.py
@@ -327,7 +327,7 @@ def write_compiled_methods(project_dir, compiled_methods):
         if os.path.exists(filepath):
             logger.warning("Overwrite file %s %s" % (filepath, method_triple))
 
-        with open(filepath, 'w') as fp:
+        with open(filepath, 'w', encoding='utf-8') as fp:
             fp.write('#include "Dex2C.h"\n' + code)
 
     with open(os.path.join(source_dir, 'compiled_methods.txt'), 'w') as fp:
@@ -387,7 +387,7 @@ def write_dummy_dynamic_register(project_dir):
         os.makedirs(source_dir)
 
     filepath = os.path.join(source_dir, 'DynamicRegister.cpp')
-    with open(filepath, 'w') as fp:
+    with open(filepath, 'w', encoding='utf-8') as fp:
         fp.write('#include "DynamicRegister.h"\n\nconst char *dynamic_register_compile_methods(JNIEnv *env) { return nullptr; }')
 
 def write_dynamic_register(project_dir, compiled_methods, method_prototypes):
@@ -438,7 +438,7 @@ def write_dynamic_register(project_dir, compiled_methods, method_prototypes):
 
     # Write DynamicRegister.cpp
     filepath = os.path.join(source_dir, 'DynamicRegister.cpp')
-    with open(filepath, 'w') as fp:
+    with open(filepath, 'w', encoding='utf-8') as fp:
         fp.write('#include "DynamicRegister.h"\n\n')
         fp.write('\n'.join(extern_block))
         fp.write('\n\nconst char *dynamic_register_compile_methods(JNIEnv *env) {')


### PR DESCRIPTION
App will be crash when `D2C_RESOLVE_FIELD(...)` field_name is Chinese.
Like:

    LOGD("22:iget \x76\x33\x2c\x20\x76\x33\x2c\x20\x4c\x63\x6f\x6d\x2f\x61\x6e\x64\x72\x6f\x69\x64\x2f\x73\x75\x70\x70\x6f\x72\x74\x2f\x4d\x65\x6e\x75\x3b\x2d\x3e\xe7\x99\xbd\xe8\x89\xb2\x20\x49");
    {
    #define EX_HANDLE EX_UnwindBlock
    D2C_NOT_NULL(v3);
    jclass &clz = cls1;
    jfieldID &fld = fld1;
    D2C_RESOLVE_FIELD(clz, fld, "com/android/support/Menu", "��ɫ", "I");
    v6 = (jint)env->GetIntField(v3, fld);
    D2C_CHECK_PENDING_EX;
    #undef EX_HANDLE
    }